### PR TITLE
README.rst: avoid docstring syntax for python -OO compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ and instead can write only the help message--*the way you want it*.
 
 .. code:: python
 
-    """Naval Fate.
+    DOC = """Naval Fate.
 
     Usage:
       naval_fate.py ship new <name>...
@@ -70,11 +70,15 @@ and instead can write only the help message--*the way you want it*.
       --drifting    Drifting mine.
 
     """
+    # Used a var instead of docstring syntax to survive `python -OO` stripping them.
+    # Assigning to __doc__ is optional but good for `pydoc` and `help()`.
+    __doc__ = DOC
+
     from docopt import docopt
 
 
     if __name__ == '__main__':
-        arguments = docopt(__doc__, version='Naval Fate 2.0')
+        arguments = docopt(DOC, version='Naval Fate 2.0')
         print(arguments)
 
 Beat that! The option parser is generated based on the docstring above
@@ -87,6 +91,9 @@ information in it to make a parser*.
 
 Also, `PEP 257 <http://www.python.org/dev/peps/pep-0257/>`_ recommends
 putting help message in the module docstrings.
+However, docstring syntax gets stripped in `python -OO` mode;
+the recipe above uses a regular variable which works either way
+(and still assigns `__doc__` at run time so pydoc will find it).
 
 Installation
 ======================================================================


### PR DESCRIPTION
The current recommended recipe using docstring *syntax* is incompatible with python -OO mode.
`TypeError: expected string or bytes-like object`
https://discuss.python.org/t/stop-ignoring-asserts-when-running-in-optimized-mode/13132/31

Who cares?
- `-OO` slightly reduces RAM usage.
- If one distributes a script as a self-contained executable, it's tempting to precompile .pyo with docstring stripping for reduced dependencies size.  But any files using docopt as recommended will stop working.
- It's an easily avoidable "papercut".  In some downstream-repackaging situations it might even happen to unsuspecting end users?
- Finally, I wish every tool relying on docstrings for functionality (which is cool :+1:) at least mentioned the existance of `-OO`...

This PR mentions the problem in the README, and modifies the default recipe so it's `-OO`-safe.

----

* There is a shorter recipe that happens to work with -OO:
  
      __doc__ = """Naval Fate.
      ...
      """

  That's it!  Because syntactically it's an assignment statement, not native docstring syntax, it doesn't get stripped.  And it executes *after* `__doc__` is initialized to `None` by (lack of) native docstring syntax, so no conflict.
  
  But that feels too "magic" to me (and really requires a comment for the next programmer to not remove it).  IMHO the explicit use of a different variable `DOC = ...` is clearer, and highlights the independent goals of:
  1. `docopt()` — which can take whatever string you give it;
  2. `pydoc` / `help()` / other introspection which may look at `.__doc__`.
  
  Which do you think is better to document?